### PR TITLE
v1.6.0: `wsp cache path` + `wsp workspace path|info` introspection commands (mirror of workspace-cli#2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `wsp` are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+## [1.6.0] — 2026-05-06
+
+Read-only introspection commands. The CLI is now the single source of truth for its own internal paths and resolved state — no more relying on docs/memory which can drift from code (a real recent incident: an operator wiped `~/.cache/wsp/` thinking that was the cache root, when the actual default is `~/.wsp/cache/`; the wipe was a silent no-op).
+
+### Added
+- `wsp cache path [--json]` — print the active cache root, sourced from `git_ops.cache_root()`. With `--json`, also reports the env var name (`WSP_CACHE_DIR`) and whether the path exists today.
+- `wsp workspace path [--json]` — walk up from the current directory to find the workspace root (dir containing `workspace.yml`). Exits non-zero with structured error if none found.
+- `wsp workspace info [--json]` — structured snapshot of the current workspace: name, schema, product, declared stacks (with kind: stack | odoo_modules), Odoo modules, extra repos, and override counts.
+- `wsp/introspect.py` — new module with the underlying pure functions (`cache_path()`, `find_workspace_root()`, `workspace_info()`). Read-only and side-effect free; reusable by future wrappers without going through the CLI.
+
+### Why this matters
+Authoritative self-reporting closes a class of "I deleted the wrong thing" bugs caused by stale documentation and chat-message drift. Operators and agents can ask `wsp` directly.
+
 ## [1.5.1] — 2026-05-05
 
 Onboard-product Step 8 fix. The previous "fallback when MCP unavailable" instruction (`git clone <docs-repo>`) didn't specify where to clone, leading agents to clone into the user's workspace and pollute it. Fix: prefer `gh api -X PUT` direct (no clone), or /tmp clone with explicit cleanup.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wsp"
-version = "1.5.1"
+version = "1.6.0"
 description = "wsp — the AWaC (Agent Workspace as Code) CLI. Compose AI-agent workspaces declaratively from versioned stack repos."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_introspect.py
+++ b/tests/test_introspect.py
@@ -1,0 +1,167 @@
+"""Tests for wsp.introspect — read-only state introspection."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from wsp import introspect
+from wsp.cli import main
+
+
+# ----------------------------------------------------------------------
+# Library-level
+# ----------------------------------------------------------------------
+
+
+def test_cache_path_default(monkeypatch):
+    monkeypatch.delenv("WSP_CACHE_DIR", raising=False)
+    p = introspect.cache_path()
+    assert p == Path.home() / ".wsp" / "cache"
+
+
+def test_cache_path_respects_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("WSP_CACHE_DIR", str(tmp_path))
+    assert introspect.cache_path() == Path(str(tmp_path))
+
+
+def test_find_workspace_root_walks_ancestors(tmp_path):
+    nested = tmp_path / "a" / "b" / "c"
+    nested.mkdir(parents=True)
+    (tmp_path / "workspace.yml").write_text(
+        "name: t\nschema: awac/1\nstacks:\n  - core\n",
+        encoding="utf-8",
+    )
+    assert introspect.find_workspace_root(nested) == tmp_path.resolve()
+
+
+def test_find_workspace_root_returns_none_when_absent(tmp_path):
+    nested = tmp_path / "deeply" / "nested"
+    nested.mkdir(parents=True)
+    # Walk up from `nested` — there's no workspace.yml above it inside tmp_path.
+    # We can't guarantee there isn't one above tmp_path itself on some CI
+    # filesystems, so just assert the fn either returns None or a path
+    # outside tmp_path.
+    found = introspect.find_workspace_root(nested)
+    if found is not None:
+        assert tmp_path.resolve() not in found.parents and found != tmp_path.resolve()
+
+
+def test_workspace_info_found(tmp_path):
+    (tmp_path / "workspace.yml").write_text(
+        "name: my-ws\n"
+        "schema: awac/1\n"
+        "stacks:\n"
+        "  - core\n"
+        "  - org: odoopartners\n"
+        "    modules: [mod_a, mod_b]\n",
+        encoding="utf-8",
+    )
+    info = introspect.workspace_info(tmp_path)
+    assert info["workspace_found"] is True
+    assert info["name"] == "my-ws"
+    assert info["schema"] == "awac/1"
+    assert any(s["kind"] == "stack" and s["ref"] == "core" for s in info["stacks"])
+    odoo = next(s for s in info["stacks"] if s["kind"] == "odoo_modules")
+    assert odoo["org"] == "odoopartners"
+    assert odoo["modules"] == ["mod_a", "mod_b"]
+
+
+def test_workspace_info_not_found(tmp_path):
+    # Use a temp dir we control, walking up from it. If a parent of tmp_path
+    # happens to have a workspace.yml (rare in CI but possible), info is
+    # found — assert only the negative-shape contract.
+    info = introspect.workspace_info(tmp_path)
+    if not info["workspace_found"]:
+        assert "searched_from" in info
+
+
+# ----------------------------------------------------------------------
+# CLI surface
+# ----------------------------------------------------------------------
+
+
+def test_cli_cache_path_prints_default(monkeypatch):
+    monkeypatch.delenv("WSP_CACHE_DIR", raising=False)
+    runner = CliRunner()
+    res = runner.invoke(main, ["cache", "path"])
+    assert res.exit_code == 0, res.output
+    assert ".wsp" in res.output and "cache" in res.output
+
+
+def test_cli_cache_path_json(monkeypatch, tmp_path):
+    monkeypatch.setenv("WSP_CACHE_DIR", str(tmp_path))
+    runner = CliRunner()
+    res = runner.invoke(main, ["cache", "path", "--json"])
+    assert res.exit_code == 0, res.output
+    payload = json.loads(res.output)
+    assert payload["path"] == str(tmp_path)
+    assert payload["env_var"] == "WSP_CACHE_DIR"
+    assert "exists" in payload
+
+
+def test_cli_workspace_path(tmp_path):
+    (tmp_path / "workspace.yml").write_text(
+        "name: t\nschema: awac/1\nstacks:\n  - core\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    res = runner.invoke(main, ["workspace", "path"], env={"PWD": str(tmp_path)})
+    # Click's CliRunner doesn't honor PWD; chdir inside the test.
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        res = runner.invoke(main, ["workspace", "path"])
+    finally:
+        os.chdir(cwd)
+    assert res.exit_code == 0, res.output
+    assert str(tmp_path.resolve()) in res.output
+
+
+def test_cli_workspace_info_json(tmp_path):
+    (tmp_path / "workspace.yml").write_text(
+        "name: probe\n"
+        "schema: awac/1\n"
+        "stacks:\n"
+        "  - core\n"
+        "  - aws\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        res = runner.invoke(main, ["workspace", "info", "--json"])
+    finally:
+        os.chdir(cwd)
+    assert res.exit_code == 0, res.output
+    payload = json.loads(res.output)
+    assert payload["workspace_found"] is True
+    assert payload["name"] == "probe"
+    assert {s["ref"] for s in payload["stacks"] if s["kind"] == "stack"} == {"core", "aws"}
+
+
+def test_cli_workspace_info_not_found_errors(tmp_path):
+    runner = CliRunner()
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        res = runner.invoke(main, ["workspace", "info", "--json"])
+    finally:
+        os.chdir(cwd)
+    # If our tmp_path has no workspace.yml above it, exit non-zero.
+    # If it DID find one (some CI quirk), accept exit 0.
+    assert res.exit_code in (0, 1)
+
+
+def test_agent_manifest_lists_new_commands():
+    runner = CliRunner()
+    res = runner.invoke(main, ["--agent-manifest"])
+    assert res.exit_code == 0
+    payload = json.loads(res.output)
+    names = {c["name"] for c in payload["commands"]}
+    assert "cache" in names
+    assert "workspace" in names

--- a/wsp/__init__.py
+++ b/wsp/__init__.py
@@ -1,4 +1,4 @@
 """wsp — the AWaC (Agent Workspace as Code) CLI."""
 
-__version__ = "1.5.1"
+__version__ = "1.6.0"
 __schema__ = "awac/2"

--- a/wsp/cli.py
+++ b/wsp/cli.py
@@ -32,7 +32,7 @@ for _stream in (sys.stdout, sys.stderr):
 
 from wsp import __schema__ as WSP_SCHEMA
 from wsp import __version__ as WSP_VERSION
-from wsp import audit_action, bootstrap_action, deploy_action, errors, git_ops, governance, manifest, registry, scaffold_repo_action, scaffold_stack_action, secrets_action, status_action, sync_action
+from wsp import audit_action, bootstrap_action, deploy_action, errors, git_ops, governance, introspect, manifest, registry, scaffold_repo_action, scaffold_stack_action, secrets_action, status_action, sync_action
 
 import hashlib
 
@@ -156,6 +156,20 @@ AGENT_MANIFEST = {
             "summary": "List stack shortcuts in the registry.",
             "options": [{"name": "--json", "type": "flag"}],
             "json_keys": ["shortcuts"],
+        },
+        {
+            "name": "cache",
+            "summary": "Inspect the wsp local cache. Subcommand: path.",
+            "args": [{"name": "subcommand", "required": True, "choices": ["path"]}],
+            "options": [{"name": "--json", "type": "flag"}],
+            "json_keys": ["path", "env_var", "exists"],
+        },
+        {
+            "name": "workspace",
+            "summary": "Inspect the current workspace (dir containing workspace.yml). Subcommands: path, info.",
+            "args": [{"name": "subcommand", "required": True, "choices": ["path", "info"]}],
+            "options": [{"name": "--json", "type": "flag"}],
+            "json_keys": ["workspace_found", "path", "manifest_path", "name", "schema", "product", "stacks", "modules", "extra_repos", "deploy_overrides_count", "devvault_overrides_count"],
         },
         {
             "name": "doctor",
@@ -829,6 +843,108 @@ def shortcuts(as_json: bool) -> None:
                 click.echo(f"{s['shortcut']:14s} → {s['target']}")
     except errors.WspError as exc:
         _emit_error(exc, as_json)
+
+
+@main.group()
+def cache() -> None:
+    """Inspect the wsp local cache (where stack repos are cloned)."""
+
+
+@cache.command("path")
+@click.option("--json", "as_json", is_flag=True)
+def cache_path_cmd(as_json: bool) -> None:
+    """Print the active cache root.
+
+    The cache root is `$WSP_CACHE_DIR` if set, otherwise `~/.wsp/cache/`
+    (NOT `~/.cache/wsp/` — common XDG-style mistake). This command always
+    reports the path the CLI actually uses, so docs/memory drift cannot
+    misdirect a manual cleanup.
+    """
+    p = introspect.cache_path()
+    if as_json:
+        _emit({
+            "path": str(p),
+            "env_var": "WSP_CACHE_DIR",
+            "exists": p.exists(),
+        }, as_json=True)
+    else:
+        click.echo(str(p))
+
+
+@main.group()
+def workspace() -> None:
+    """Inspect the current workspace (the dir containing workspace.yml)."""
+
+
+@workspace.command("path")
+@click.option("--json", "as_json", is_flag=True)
+def workspace_path_cmd(as_json: bool) -> None:
+    """Print the absolute path of the current workspace root.
+
+    Walks up from the current directory until a `workspace.yml` is found.
+    Exits non-zero (and emits a structured error) if none is found.
+    """
+    root = introspect.find_workspace_root(Path.cwd())
+    if root is None:
+        exc = errors.WspError(
+            code="WSP_022", category="filesystem",
+            cause="No workspace.yml found in the current directory or any ancestor.",
+            remediation="Run from a wsp workspace, or create one with `wsp init`.",
+            details={"searched_from": str(Path.cwd().resolve())},
+        )
+        _emit_error(exc, as_json)
+        return
+    if as_json:
+        _emit({"path": str(root)}, as_json=True)
+    else:
+        click.echo(str(root))
+
+
+@workspace.command("info")
+@click.option("--json", "as_json", is_flag=True)
+def workspace_info_cmd(as_json: bool) -> None:
+    """Print structured metadata about the current workspace.
+
+    Includes: name, schema, product (if any), declared stacks, Odoo
+    modules, extra repos, and override counts. Use --json for an
+    agent-consumable form.
+    """
+    try:
+        info = introspect.workspace_info(Path.cwd())
+    except errors.WspError as exc:
+        _emit_error(exc, as_json)
+        return
+    if not info["workspace_found"]:
+        exc = errors.WspError(
+            code="WSP_022", category="filesystem",
+            cause="No workspace.yml found in the current directory or any ancestor.",
+            remediation="Run from a wsp workspace, or create one with `wsp init`.",
+            details={"searched_from": info["searched_from"]},
+        )
+        _emit_error(exc, as_json)
+        return
+    if as_json:
+        _emit(info, as_json=True)
+    else:
+        click.echo(f"workspace: {info['name']}")
+        click.echo(f"  path:    {info['path']}")
+        click.echo(f"  schema:  {info['schema']}")
+        if info.get("product"):
+            click.echo(f"  product: {info['product']}")
+        click.echo(f"  stacks ({len(info['stacks'])}):")
+        for s in info["stacks"]:
+            if s["kind"] == "odoo_modules":
+                click.echo(f"    - odoo_modules @ {s['org']}: {', '.join(s['modules'])}")
+            else:
+                click.echo(f"    - {s['ref']}")
+        if info["extra_repos"]:
+            click.echo(f"  extra_repos ({len(info['extra_repos'])}):")
+            for e in info["extra_repos"]:
+                click.echo(f"    - {e['full']}@{e['branch']}")
+        if info["deploy_overrides_count"]:
+            click.echo(f"  deploy_overrides: {info['deploy_overrides_count']}")
+        if info["devvault_overrides_count"]:
+            click.echo(f"  devvault_overrides: {info['devvault_overrides_count']}")
 
 
 @main.command()

--- a/wsp/introspect.py
+++ b/wsp/introspect.py
@@ -1,0 +1,101 @@
+"""Read-only introspection of wsp's local state.
+
+Pure functions that surface paths and metadata the CLI computes
+internally — cache location, workspace root, resolved manifest data.
+
+Why this module exists: paths and metadata previously lived in three
+places (git_ops.py, the CLI's bootstrap_action, end-user docs). When
+docs drifted from code (e.g. v1.5.x docs said `~/.cache/wsp/` while
+the code used `~/.wsp/cache/`), users wiped the wrong directory and
+got silent no-ops. Centralizing introspection here, and exposing it
+via `wsp cache path` / `wsp workspace path|info`, eliminates the gap:
+the CLI reports its own state authoritatively, no copy-paste from docs.
+
+All functions are read-only and side-effect free. They never write
+files, never network, never spawn subprocesses.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from wsp import git_ops, manifest
+
+
+def cache_path() -> Path:
+    """Return the active wsp cache root (`$WSP_CACHE_DIR` or default)."""
+    return git_ops.cache_root()
+
+
+def find_workspace_root(start: Path) -> Path | None:
+    """Walk up from `start` looking for a directory containing `workspace.yml`.
+
+    Returns the directory if found, or None if the search reaches the
+    filesystem root without finding one. The caller decides how to handle
+    the not-found case (the CLI prints a friendly message; library
+    callers may prefer to raise).
+    """
+    cur = Path(start).resolve()
+    while True:
+        if (cur / "workspace.yml").exists():
+            return cur
+        if cur.parent == cur:
+            return None
+        cur = cur.parent
+
+
+def workspace_info(start: Path) -> dict[str, Any]:
+    """Return a structured snapshot of the workspace at or above `start`.
+
+    Shape (when found):
+        {
+          "workspace_found": True,
+          "path": "<absolute path to workspace root>",
+          "manifest_path": "<absolute path to workspace.yml>",
+          "name": "<workspace name>",
+          "schema": "awac/1" | "awac/2",
+          "product": "<product slug>" | None,
+          "stacks": [{"ref": "core"} | {"org": "odoopartners", "modules": [...]}],
+          "modules": [...],          # Odoo modules (top-level shortcut)
+          "extra_repos": [...],
+          "deploy_overrides_count": <int>,
+          "devvault_overrides_count": <int>,
+        }
+
+    Shape (when no workspace found above `start`):
+        {"workspace_found": False, "searched_from": "<absolute path>"}
+    """
+    root = find_workspace_root(start)
+    if root is None:
+        return {
+            "workspace_found": False,
+            "searched_from": str(Path(start).resolve()),
+        }
+    m = manifest.load_manifest(root / "workspace.yml")
+    stacks_summary: list[dict[str, Any]] = []
+    for s in m.stacks:
+        if s.is_odoo_modules:
+            stacks_summary.append({
+                "kind": "odoo_modules",
+                "org": s.odoo_org,
+                "modules": list(s.odoo_modules),
+            })
+        else:
+            stacks_summary.append({
+                "kind": "stack",
+                "ref": s.ref,
+            })
+    return {
+        "workspace_found": True,
+        "path": str(root),
+        "manifest_path": str(root / "workspace.yml"),
+        "name": m.name,
+        "schema": m.schema,
+        "product": m.product,
+        "stacks": stacks_summary,
+        "modules": list(m.modules),
+        "extra_repos": [{"full": e.full, "branch": e.branch, "path": e.path} for e in m.extra_repos],
+        "deploy_overrides_count": len(m.deploy_overrides),
+        "devvault_overrides_count": len(m.devvault_overrides),
+    }


### PR DESCRIPTION
## Summary

Mirror of getGanemo/workspace-cli#2 (private side, already merged). Adds three read-only introspection commands so the CLI authoritatively reports its own internal state.

- `wsp cache path [--json]` — active cache root
- `wsp workspace path [--json]` — walks up to find the workspace root
- `wsp workspace info [--json]` — structured workspace snapshot

Underlying pure functions live in `wsp/introspect.py` — reusable by future HTTP/library wrappers without going through Click.

## Why

Real incident: an operator wiped `~/.cache/wsp/` (XDG-style guess) thinking that was the cache root, but the actual default is `~/.wsp/cache/`. The wipe was a silent no-op. Path was correct in code (`git_ops.cache_root()`) but propagated wrong via documentation and chat. The CLI should be the single source of truth for its own paths.

## Test plan

- [x] 12 new tests in `tests/test_introspect.py`
- [x] Full suite green: 111 tests, 0 failures
- [x] Manual smoke: commands work, `--json` returns valid shape, `--agent-manifest` lists them

## Migration

None required. Pure additions.